### PR TITLE
provola-core: use python3 as interpreter for python

### DIFF
--- a/provola-core/src/build/python.rs
+++ b/provola-core/src/build/python.rs
@@ -1,3 +1,3 @@
 pub(crate) fn build(source: &crate::Source) -> Result<crate::Executable, crate::Error> {
-    super::interpret(source, "python")
+    super::interpret(source, "python3")
 }


### PR DESCRIPTION
On some distros python is not an alias for python3 but for python2
which should not installed by default anymore. So use python3 instead.